### PR TITLE
fix console input in README_ja and update Volume path in docker-compose

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -45,7 +45,6 @@ docker exec -it redis-server sh
 127.0.0.1:6379> hset key test test-server:3333/welcome
 127.0.0.1:6379> exit
 > exit
-> exit
 
 # Check apidoor works
 curl -H "Content-Type: application/json" -H "Authorization:key" localhost:3000/test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
             - LOG_PATH=/log.csv
             - NO_PROXY=test-server
         volumes:
-            - "/log:/log"
+            - "./log:/log"
     management-front:
         build: ./management-front
         container_name: management-front


### PR DESCRIPTION
* README_ja.md の変更
getting-started のコンソール入力例の修正をした。

* docker-compose.mdのvolumesの変更
`"/log:/log"`を`"./log:/log"`とプロジェクト内での相対パス指定に変更。