### PR TITLE
Fieldsのテストを追加

### DIFF
--- a/gateway/model_test.go
+++ b/gateway/model_test.go
@@ -1,79 +1,136 @@
 package gateway_test
 
-//type apinumtest struct {
-//	num int
-//	max interface{}
-//	err error
-//}
-//
-//var apinumdata = []apinumtest{
-//	// valid request
-//	{
-//		num: 2,
-//		max: 4,
-//		err: nil,
-//	},
-//	// valid request(boundary)
-//	{
-//		num: 2,
-//		max: 3,
-//		err: nil,
-//	},
-//	// valid request(permit unlimited call)
-//	{
-//		num: 2,
-//		max: "-",
-//		err: nil,
-//	},
-//	// invalid request
-//	{
-//		num: 2,
-//		max: 1,
-//		err: errors.New("limit exceeded"),
-//	},
-//	// invalid request(boundary)
-//	{
-//		num: 2,
-//		max: 2,
-//		err: errors.New("limit exceeded"),
-//	},
-//	// unexpected value in data
-//	{
-//		num: 2,
-//		max: "unlimited",
-//		err: errors.New("unexpected limit value"),
-//	},
-//	// unexpected value in data
-//	{
-//		num: 2,
-//		max: false,
-//		err: errors.New("unexpected limit value"),
-//	},
-//}
-//
-//func TestAPILimitChecker(t *testing.T) {
-//	for i, tt := range apinumdata {
-//		gateway.APIData["key"] = []gateway.Field{
-//			{
-//				Template: *gateway.NewURITemplate("/path"),
-//				Path:     *gateway.NewURITemplate("/path"),
-//				Num:      tt.num,
-//				Max:      tt.max,
-//			},
-//		}
-//
-//		switch err := gateway.APILimitChecker("key", "path"); err {
-//		case nil:
-//			if tt.err != nil {
-//				t.Fatalf("case %d: expected %v, get %v", i, tt.err, err)
-//			}
-//		default:
-//			if tt.err == nil {
-//				t.Fatalf("case %d: expected %v, get %v", i, tt.err, err)
-//			}
-//			if err.Error() != tt.err.Error() {
-//				t.Fatalf("case %d: expected %v, get %v", i, tt.err, err)
-//			}
-//		}
-//	}
-//}
+import (
+	"errors"
+	"gateway"
+	"testing"
+)
+
+type fieldsURITest struct {
+	input  string
+	output string
+	err    error
+}
+
+type fieldsCheckAPILimitTest struct {
+	input string
+	err   error
+}
+
+var URITestData = []fieldsURITest{
+	// valid path
+	{
+		input:  "/normal",
+		output: "normal/dist",
+		err:    nil,
+	},
+	// invalid path
+	{
+		input:  "/invalid",
+		output: "",
+		err:    &gateway.MyError{Message: "unauthorized request"},
+	},
+}
+
+var checkAPILimitTestData = []fieldsCheckAPILimitTest{
+	// valid request
+	{
+		input: "normal",
+		err:   nil,
+	},
+	// limit exceeded
+	{
+		input: "exceeded",
+		err:   errors.New("limit exceeded"),
+	},
+	// valid request
+	{
+		input: "unlimited",
+		err:   nil,
+	},
+	// invalid type in limit
+	{
+		input: "error/type",
+		err:   errors.New("unexpected limit value"),
+	},
+	// invalid value in limit
+	{
+		input: "error/value",
+		err:   errors.New("unexpected limit value"),
+	},
+	// invalid path
+	{
+		input: "invalid",
+		err:   nil,
+	},
+}
+
+var fieldsSample = gateway.Fields{
+	{
+		Template: *gateway.NewURITemplate("/normal"),
+		Path:     *gateway.NewURITemplate("/normal/dist"),
+		Num:      5,
+		Max:      10,
+	},
+	{
+		Template: *gateway.NewURITemplate("/exceeded"),
+		Path:     *gateway.NewURITemplate("/exceeded/dist"),
+		Num:      5,
+		Max:      2,
+	},
+	{
+		Template: *gateway.NewURITemplate("/unlimited"),
+		Path:     *gateway.NewURITemplate("/unlimited/dist"),
+		Num:      5,
+		Max:      "-",
+	},
+	{
+		Template: *gateway.NewURITemplate("/error/type"),
+		Path:     *gateway.NewURITemplate("/error/type/dist"),
+		Num:      5,
+		Max:      false,
+	},
+	{
+		Template: *gateway.NewURITemplate("/error/value"),
+		Path:     *gateway.NewURITemplate("/error/value/dist"),
+		Num:      5,
+		Max:      "unlimited",
+	},
+}
+
+func TestFields(t *testing.T) {
+	for i, tt := range URITestData {
+		path, err := fieldsSample.URI(tt.input)
+
+		if tt.output != path {
+			t.Fatalf("case %d: unexpected result %s, want %s", i, path, tt.output)
+		}
+		if tt.err == nil && err != nil {
+			t.Fatalf("case %d: unexpected error %s, want nil", i, err.Error())
+		}
+		if tt.err != nil && err == nil {
+			t.Fatalf("case %d: unexpected error nil, want %s", i, tt.err.Error())
+		}
+		if tt.err != nil && err != nil {
+			if tt.err.Error() != err.Error() {
+				t.Fatalf("case %d: unexpected error %s, want %s", i, err.Error(), tt.err.Error())
+			}
+		}
+	}
+
+	for i, tt := range checkAPILimitTestData {
+		err := fieldsSample.CheckAPILimit(tt.input)
+
+		if tt.err == nil && err != nil {
+			t.Fatalf("case %d: unexpected error %s, want nil", i, err.Error())
+		}
+		if tt.err != nil && err == nil {
+			t.Fatalf("case %d: unexpected error nil, want %s", i, tt.err.Error())
+		}
+		if tt.err != nil && err != nil {
+			if tt.err.Error() != err.Error() {
+				t.Fatalf("case %d: unexpected error %s, want %s", i, err.Error(), tt.err.Error())
+			}
+		}
+	}
+}


### PR DESCRIPTION
#24 の一部に対応。
`Fields.URI` と `Fields.CheckAPILimit` に対するテーブル駆動テストを追加した。

`URITestData` が `Fields.URI`、`checkAPILimitTestData` が `Fields.CheckAPILimitTestData` のテストデータにそれぞれ対応している。`fieldsSample` は `Fields` に入り得る `Field` を網羅的に追加したもの。

<img width="299" alt="coverage" src="https://user-images.githubusercontent.com/50895997/131671381-600e0ded-9143-4ecf-bf1b-dd277ea390b2.png">
