### PR TITLE
test: fix test for handler, add test case

### DIFF
--- a/gateway/delete_handler.go
+++ b/gateway/delete_handler.go
@@ -16,6 +16,7 @@ func DeleteHandler(w http.ResponseWriter, r *http.Request) {
 	if apikey == "" {
 		log.Print("No authorization key")
 		http.Error(w, "no authorization", http.StatusBadRequest)
+		return
 	}
 
 	fields, err := GetFields(r.Context(), apikey)

--- a/gateway/get_handler.go
+++ b/gateway/get_handler.go
@@ -16,6 +16,7 @@ func GetHandler(w http.ResponseWriter, r *http.Request) {
 	if apikey == "" {
 		log.Print("No authorization key")
 		http.Error(w, "no authorization", http.StatusBadRequest)
+		return
 	}
 
 	fields, err := GetFields(r.Context(), apikey)

--- a/gateway/post_handler.go
+++ b/gateway/post_handler.go
@@ -16,6 +16,7 @@ func PostHandler(w http.ResponseWriter, r *http.Request) {
 	if apikey == "" {
 		log.Print("No authorization key")
 		http.Error(w, "no authorization", http.StatusBadRequest)
+		return
 	}
 	fields, err := GetFields(r.Context(), apikey)
 	if err != nil {

--- a/gateway/put_handler.go
+++ b/gateway/put_handler.go
@@ -16,6 +16,7 @@ func PutHandler(w http.ResponseWriter, r *http.Request) {
 	if apikey == "" {
 		log.Print("No authorization key")
 		http.Error(w, "no authorization", http.StatusBadRequest)
+		return
 	}
 
 	fields, err := GetFields(r.Context(), apikey)


### PR DESCRIPTION
- `model.go` の変更に伴いハンドラのテストコードを修正
- Authorization ヘッダがない時のハンドラの挙動を修正し、テストケースも追加
- GET以外のハンドラについても一度にテストを行うようテストコードを修正

`get_handler.go` でいうL37-40, L45-48, L53-56 が coverage から外れている。(POST, PUT, DELETE も同じことをしている部分が外れている)
- `fields.CheckAPILimit` に関しては `model_test.go` でテストを代用。
- `http.NewRequest` の初期化時と `http.DefaultClient.Do` 実行時に意図的にエラーを起こすことが出来ず coverage から外れている。