### PR TITLE
READMEのAPIルーティング登録方法の修正等

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Prerequisites:
 
 Flow：
 
-```
+```bash
 # Clone me
 git clone https://github.com/future-architect/apidoor.git
 cd apidoor
@@ -44,12 +44,9 @@ docker-compose build \
 # Launch apidoor services
 docker-compose up -d
 
-# Set your first API routing
-docker exec -it redis-server sh
-> redis-cli
-127.0.0.1:6379> hset key test test-server:3333/welcome
-127.0.0.1:6379> exit
-> exit
+# Set your first API routing through management-api
+curl -X POST -H "Content-Type: application/json" \
+-d '{"api_key": "key", "path": "test", "forward_url": "test-server:3333/welcome"}' localhost:3001/mgmt/api
 
 # Check apidoor works
 curl -H "Content-Type: application/json" -H "Authorization:key" localhost:3000/test

--- a/README_ja.md
+++ b/README_ja.md
@@ -24,7 +24,7 @@ Prerequisites:
 
 Flow：
 
-```
+```bash
 # Clone me
 git clone https://github.com/future-architect/apidoor.git
 cd apidoor
@@ -39,12 +39,9 @@ docker-compose build \
 # Launch apidoor services
 docker-compose up -d
 
-# Set your first API routing
-docker exec -it redis-server sh
-> redis-cli
-127.0.0.1:6379> hset key test test-server:3333/welcome
-127.0.0.1:6379> exit
-> exit
+# Set your first API routing through management-api
+curl -X POST -H "Content-Type: application/json" \
+-d '{"api_key": "key", "path": "test", "forward_url": "test-server:3333/welcome"}' localhost:3001/mgmt/api
 
 # Check apidoor works
 curl -H "Content-Type: application/json" -H "Authorization:key" localhost:3000/test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
             - WRITETIMEOUT=20
             - IDLETIMEOUT=5
             - MAXHEADERBYTES=1048576
-            - API_DB_TYPE=REDIS
+            - DB_TYPE=REDIS
             - REDIS_HOST=redis
             - REDIS_PORT=6379
             - LOG_PATH=/log/log.csv
@@ -50,6 +50,8 @@ services:
     test-server:
         build: ./quickstart
         container_name: test-server
+        ports:
+            - "3333:3333"
         environment:
             - NO_PROXY=gateway
     postgres:

--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -7,5 +7,6 @@ test:
 	export WRITETIMEOUT=20; \
 	export IDLETIMEOUT=5; \
 	export MAXHEADERBYTES="1<<20"; \
+	export DB_TYPE="TEST"; \
 	export LOG_PATH="./testdata/log/log.csv"; \
 	go test -race -v ./

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -7,7 +7,8 @@
 以下の環境で動作を確認しています。
 - Ubuntu 20.04.2
 - go 1.16.4
-- redis-server 6.2.3
+- redis-server 6.2.3 (redis使用の場合)
+- localstack 0.12.17 (dynamoDB使用の場合)
 
 ## 準備
 以下の環境変数の設定が必要です。
@@ -21,10 +22,24 @@
     - リクエストを待つ際のタイムアウト(sec)(ex. 5)
 - `MAXHEADERBYTES`
     - リクエストヘッダの容量の許可される最大値(ex. 1<<20)
-- `REDIS_HOST`
-    - redisのホストアドレス(ex. localhost:6379)
 - `LOG_PATH`
     - ログファイル(CSV形式)の出力先パス(ex. ./log.csv)
+- `DB_TYPE`
+    - 使用するDB。`REDIS`または`DYNAMO`。
+
+以下は使用するDBに応じて設定
+
+redisの場合
+- `REDIS_HOST`
+    - redisのホストアドレス(ex. localhost)
+- `REDIS_PORT`
+    - redisのlistenポート(ex. 6379)
+
+dynamoDBの場合
+- `DYNAMO_TABLE_API_FORWARDING`
+    - APIルーティングを管理するテーブル名
+- `DYNAMO_ENDPOINT`
+    - localstack使用時に必要。接続先のホスト、ポート (ex. http://localhost:4566)
 
 `source env.sh`でローカル実行用の環境変数を読み込むことが出来ます。
 

--- a/gateway/db.go
+++ b/gateway/db.go
@@ -27,7 +27,7 @@ func createDBDriver(dbType string) (DB, error) {
 		return NewRedisDB(), nil
 	case "DYNAMO":
 		return NewDynamoDB(), nil
-	case "":
+	case "TEST":
 		log.Print("db driver is not set")
 		return nil, nil
 	default:

--- a/management-api/Dockerfile
+++ b/management-api/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /management-api
 COPY go.mod go.sum ./
 RUN ["go", "mod", "download"]
 ADD *.go ./
+ADD ./apiredis/*.go apiredis/
 ADD cmd/management-api/* cmd/management-api/
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-s -w -buildid=' -trimpath -o /bin/main cmd/management-api/main.go
 


### PR DESCRIPTION
READMEにあるAPIルーティング登録をAPIを使用したものに変更

また、docker-composeの環境変数設定ミスの修正、および、panicを防止するための実装の修正