### PR TITLE
local.packages を削除

### DIFF
--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -7,8 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"local.packages/gateway"
-
+	"github.com/future-architect/apidoor/gateway"
 	"github.com/go-chi/chi/v5"
 )
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,13 +3,11 @@ module github.com/future-architect/apidoor/gateway
 go 1.16
 
 require (
-	github.com/future-architect/apidoor/gateway v0.0.0
-	github.com/aws/aws-sdk-go v1.40.37 // indirect
+	github.com/aws/aws-sdk-go v1.40.37
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/go-chi/chi/v5 v5.0.3
 	github.com/go-redis/redis/v8 v8.11.3
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
-	github.com/guregu/dynamo v1.11.0 // indirect
+	github.com/guregu/dynamo v1.11.0
 	golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f // indirect
-	local.packages/gateway v0.0.0-00010101000000-000000000000
 )

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,8 +1,9 @@
-module gateway
+module github.com/future-architect/apidoor/gateway
 
 go 1.16
 
 require (
+	github.com/future-architect/apidoor/gateway v0.0.0
 	github.com/aws/aws-sdk-go v1.40.37 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/go-chi/chi/v5 v5.0.3
@@ -12,5 +13,3 @@ require (
 	golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f // indirect
 	local.packages/gateway v0.0.0-00010101000000-000000000000
 )
-
-replace local.packages/gateway => ./

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -7,6 +7,7 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
@@ -40,6 +41,7 @@ github.com/guregu/dynamo v1.11.0/go.mod h1:h8dDh87mKIRfkSId4Qdk3PjAsNtRrldrNw72B
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -53,6 +55,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -67,7 +70,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f h1:w6wWR0H+nyVpbSAQbzVEIACVyr/h8l/BEkY6Sokc7Eg=

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -2,9 +2,10 @@ package gateway
 
 import (
 	"errors"
-	"gateway/logger"
 	"log"
 	"net/http"
+
+	"github.com/future-architect/apidoor/gateway/logger"
 )
 
 func Handler(w http.ResponseWriter, r *http.Request) {

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -2,12 +2,13 @@ package gateway_test
 
 import (
 	"context"
-	"gateway"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/future-architect/apidoor/gateway"
 )
 
 var dbHost, templatePath string

--- a/gateway/logger/logger_test.go
+++ b/gateway/logger/logger_test.go
@@ -2,10 +2,11 @@ package logger_test
 
 import (
 	"encoding/csv"
-	"gateway/logger"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/future-architect/apidoor/gateway/logger"
 )
 
 func TestUpdateLog(t *testing.T) {

--- a/gateway/model_test.go
+++ b/gateway/model_test.go
@@ -2,8 +2,9 @@ package gateway_test
 
 import (
 	"errors"
-	"gateway"
 	"testing"
+
+	"github.com/future-architect/apidoor/gateway"
 )
 
 type fieldsURITest struct {

--- a/gateway/uri_template_test.go
+++ b/gateway/uri_template_test.go
@@ -1,8 +1,9 @@
 package gateway_test
 
 import (
-	"gateway"
 	"testing"
+
+	"github.com/future-architect/apidoor/gateway"
 )
 
 type templatetest struct {


### PR DESCRIPTION
apidoor 自身の呼び出し時に github にあるコードを使わずローカルにあるコードを使っていたため、github 上にあるものから取得するように変更した。

以下の記事のようにgo1がデフォルトで取得されるため開発やテスト用にgo1ブランチで作成しているが、すべてのディレクトリにおいて対応完了後はこのブランチを削除し main から取得するようにする。
https://budougumi0617.github.io/2018/05/10/go-get-from-go1-tag-or-branch/