### PR TITLE
api使用回数の集計

### DIFF
--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -30,6 +30,7 @@ func (h DefaultHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// get all apis linked with the api key
 	fields, err := h.DataSource.GetFields(r.Context(), apikey)
 	if err != nil {
 		log.Print(err.Error())
@@ -41,6 +42,7 @@ func (h DefaultHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// look up and check the path
 	path, err := fields.URI(r.URL.Path)
 	if err != nil {
 		log.Print(err.Error())

--- a/gateway/logger/counter.go
+++ b/gateway/logger/counter.go
@@ -1,0 +1,72 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"github.com/Songmu/flextime"
+	"github.com/future-architect/apidoor/gateway/model"
+	"sync"
+	"time"
+)
+
+var (
+	APICounter = APICallCounter{}
+
+	DefaultCountValidSpan = 30 * time.Second
+	DefaultCountSpanDays  = 30
+)
+
+type APICallCounter struct {
+	sync.Map
+}
+
+func (ac *APICallCounter) GetCount(ctx context.Context, apikey string, path model.URITemplate) (int, error) {
+	key := counterKey{
+		apikey: apikey,
+		path:   path.JoinPath(),
+	}
+	return ac.getCount(ctx, key)
+}
+
+func (ac *APICallCounter) getCount(ctx context.Context, key counterKey) (int, error) {
+	stat, ok := ac.Load(key)
+	if ok {
+		stat := stat.(counterStat)
+		if flextime.Now().Before(stat.expireAt) {
+			return stat.calls, nil
+		}
+	}
+	return ac.updateCount(ctx, key)
+}
+
+func (ac *APICallCounter) updateCount(ctx context.Context, key counterKey) (int, error) {
+	count64, err := db.countAccessLogDB(ctx, key.apikey, key.path, ac.countStartAt())
+	if err != nil {
+		return 0, fmt.Errorf("count api call db error: %w", err)
+	}
+	count := int(count64)
+
+	ac.Store(key, counterStat{
+		calls:    count,
+		expireAt: ac.countExpireAt(),
+	})
+	return count, nil
+}
+
+func (ac *APICallCounter) countStartAt() time.Time {
+	return flextime.Now().AddDate(0, 0, -DefaultCountSpanDays)
+}
+
+func (ac *APICallCounter) countExpireAt() time.Time {
+	return flextime.Now().Add(DefaultCountValidSpan)
+}
+
+type counterKey struct {
+	apikey string
+	path   string
+}
+
+type counterStat struct {
+	calls    int
+	expireAt time.Time
+}

--- a/gateway/logger/counter_test.go
+++ b/gateway/logger/counter_test.go
@@ -1,0 +1,123 @@
+package logger_test
+
+import (
+	"context"
+	"github.com/Songmu/flextime"
+	"github.com/future-architect/apidoor/gateway"
+	"github.com/future-architect/apidoor/gateway/logger"
+	"github.com/future-architect/apidoor/gateway/model"
+	"testing"
+	"time"
+)
+
+var (
+	testCounter = logger.APICallCounter{}
+)
+
+func TestAPICallCounter_GetCount(t *testing.T) {
+	gateway.Setup(t,
+		`aws dynamodb --profile local --endpoint-url http://localhost:4566 create-table --cli-input-json file://../db_table/access_log_table.json`,
+		`aws dynamodb --profile local --endpoint-url http://localhost:4566 batch-write-item --request-items file://./testdata/get_counter_items.json`,
+	)
+	t.Cleanup(func() {
+		gateway.Teardown(t,
+			`aws dynamodb --profile local --endpoint-url http://localhost:4566 delete-table --table access_log`,
+		)
+	})
+	restore := flextime.Fix(time.Date(2020, 12, 15, 13, 0, 0, 0, time.UTC))
+	defer restore()
+
+	logger.DefaultCountSpanDays = 30
+
+	tests := []struct {
+		name      string
+		apikey    string
+		path      model.URITemplate
+		wantCount int
+	}{
+		{
+			name:      "count api calls correctly",
+			apikey:    "key1",
+			path:      model.NewURITemplate("api/test"),
+			wantCount: 2,
+		},
+		{
+			name:      "count result is zero",
+			apikey:    "key9",
+			path:      model.NewURITemplate("api/test"),
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := testCounter.GetCount(context.Background(), tt.apikey, tt.path)
+			if err != nil {
+				t.Errorf("get count error: %v", err)
+			}
+
+			if count != tt.wantCount {
+				t.Errorf("count result is wrong, want %d, got %d", tt.wantCount, count)
+			}
+		})
+	}
+
+}
+
+func TestAPICallCounter_GetCountWithCache(t *testing.T) {
+	gateway.Setup(t,
+		`aws dynamodb --profile local --endpoint-url http://localhost:4566 create-table --cli-input-json file://../db_table/access_log_table.json`,
+		`aws dynamodb --profile local --endpoint-url http://localhost:4566 batch-write-item --request-items file://./testdata/get_counter_items.json`,
+	)
+	t.Cleanup(func() {
+		gateway.Teardown(t,
+			`aws dynamodb --profile local --endpoint-url http://localhost:4566 delete-table --table access_log`,
+		)
+	})
+
+	startTime := time.Date(2020, 12, 15, 13, 0, 0, 0, time.UTC)
+
+	restore := flextime.Fix(startTime)
+	defer restore()
+
+	logger.DefaultCountSpanDays = 30
+	logger.DefaultCountValidSpan = 30 * time.Second
+
+	apikey := "key1"
+	pathStr := "api/test"
+	path := model.NewURITemplate(pathStr)
+
+	// get count correctly
+	testGetCount(t, apikey, path, 2)
+
+	flextime.Fix(startTime.Add(5 * time.Second))
+	putAccessLog(t, logger.LogItem{
+		Key:       apikey,
+		TimeStamp: startTime.Add(5 * time.Second).Format(time.RFC3339),
+		Path:      pathStr,
+	})
+
+	// the result is not changed, because the cache is valid
+	testGetCount(t, apikey, path, 2)
+
+	flextime.Fix(startTime.Add(35 * time.Second))
+	// the result is updated, because the cache is invalid
+	testGetCount(t, apikey, path, 3)
+
+}
+
+func testGetCount(t *testing.T, key string, path model.URITemplate, wantCount int) {
+	count, err := testCounter.GetCount(context.Background(), key, path)
+	if err != nil {
+		t.Errorf("get count error: %v", err)
+	}
+	if count != wantCount {
+		t.Errorf("count result is wrong, want %d, got %d", wantCount, count)
+	}
+}
+
+func putAccessLog(t *testing.T, item logger.LogItem) {
+	if err := db.Table(accessLogTable).Put(item).Run(); err != nil {
+		t.Errorf("put access log failed: %v", err)
+	}
+}

--- a/gateway/logger/dynamo.go
+++ b/gateway/logger/dynamo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/guregu/dynamo"
 	"log"
 	"os"
+	"time"
 )
 
 type accessLogDB struct {
@@ -45,4 +46,12 @@ func init() {
 func (ad accessLogDB) postAccessLogDB(ctx context.Context, item LogItem) error {
 	return ad.client.Table(ad.accessLogTable).
 		Put(item).RunWithContext(ctx)
+}
+
+func (ad accessLogDB) countAccessLogDB(ctx context.Context, apikey, path string, startAt time.Time) (int64, error) {
+	return ad.client.Table(ad.accessLogTable).
+		Get("api_key", apikey).
+		Range("timestamp", dynamo.GreaterOrEqual, startAt).
+		Filter("'path' = ?", path).
+		CountWithContext(ctx)
 }

--- a/gateway/logger/logger.go
+++ b/gateway/logger/logger.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/csv"
 	"errors"
-	"github.com/Songmu/flextime"
 	"io"
 	"log"
 	"net/http"
@@ -23,7 +22,7 @@ type Appender interface {
 }
 
 func UpdateDBRoutine(ctx context.Context, appender Appender, interval time.Duration, kill, finish chan bool) {
-	ticker := flextime.NewTicker(interval)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/gateway/logger/logger_test.go
+++ b/gateway/logger/logger_test.go
@@ -118,14 +118,12 @@ func TestUpdateDBRoutine(t *testing.T) {
 		t.Errorf("append access log %+v failed: %v", inputAccesses[0], err)
 	}
 
-	//check the process has not put items
-	testAccessLogDBResult(t, []logger.LogItem{})
+	testAccessLogDBResult(t, "the process has not put items", []logger.LogItem{})
 
 	// updating the db occurs during the sleep
 	time.Sleep(7 * time.Second)
 
-	//check the process has put an item
-	testAccessLogDBResult(t, []logger.LogItem{
+	testAccessLogDBResult(t, "the process has put an item", []logger.LogItem{
 		{
 			Key:  inputAccesses[0].key,
 			Path: inputAccesses[0].path,
@@ -136,43 +134,42 @@ func TestUpdateDBRoutine(t *testing.T) {
 		t.Errorf("append access log %+v failed: %v", inputAccesses[1], err)
 	}
 
-	//check the process has not put the second item
-	testAccessLogDBResult(t, []logger.LogItem{
-		{
-			Key:  inputAccesses[0].key,
-			Path: inputAccesses[0].path,
-		},
-	})
+	testAccessLogDBResult(t, "the process has not put the second item",
+		[]logger.LogItem{
+			{
+				Key:  inputAccesses[0].key,
+				Path: inputAccesses[0].path,
+			},
+		})
 
 	// updating the db occurs during the sleep
 	time.Sleep(5 * time.Second)
 
-	//check the process has put the second item and duplicate putting an item has not occurred
-	testAccessLogDBResult(t, []logger.LogItem{
-		{
-			Key:  inputAccesses[1].key,
-			Path: inputAccesses[1].path,
-		},
-		{
-			Key:  inputAccesses[0].key,
-			Path: inputAccesses[0].path,
-		},
-	})
+	testAccessLogDBResult(t, "the process has put the second item and duplicate putting an item has not occurred",
+		[]logger.LogItem{
+			{
+				Key:  inputAccesses[1].key,
+				Path: inputAccesses[1].path,
+			},
+			{
+				Key:  inputAccesses[0].key,
+				Path: inputAccesses[0].path,
+			},
+		})
 }
 
-func testAccessLogDBResult(t *testing.T, wantResult []logger.LogItem) {
+func testAccessLogDBResult(t *testing.T, name string, wantResult []logger.LogItem) {
 	result := scanAccessLog(t)
 
 	if len(result) < 1 {
 		if len(wantResult) >= 1 {
-			t.Errorf("scan access log result is empty, but want: %+v", wantResult)
+			t.Errorf("check %v: scan access log result is empty, but want: %+v", name, wantResult)
 		}
 		return
 	}
 	if diff := cmp.Diff(result, wantResult, cmpopts.IgnoreFields(logger.LogItem{}, "TimeStamp")); diff != "" {
-		t.Errorf("access log scan result differs:\n%v", diff)
+		t.Errorf("check %v: access log scan result differs:\n%v", name, diff)
 	}
-
 }
 
 func scanAccessLog(t *testing.T) []logger.LogItem {

--- a/gateway/logger/testdata/get_counter_items.json
+++ b/gateway/logger/testdata/get_counter_items.json
@@ -1,0 +1,79 @@
+{
+  "access_log": [
+    {
+      "PutRequest":{
+        "Item": {
+          "api_key": {
+            "S": "key1"
+          },
+          "timestamp": {
+            "S": "2020-12-14T06:00:00Z"
+          },
+          "path": {
+            "S": "api/test"
+          }
+        }
+      }
+    },
+    {
+      "PutRequest":{
+        "Item": {
+          "api_key": {
+            "S": "key1"
+          },
+          "timestamp": {
+            "S": "2020-12-13T06:00:00Z"
+          },
+          "path": {
+            "S": "api/test"
+          }
+        }
+      }
+    },
+    {
+      "PutRequest":{
+        "Item": {
+          "api_key": {
+            "S": "key1"
+          },
+          "timestamp": {
+            "S": "2020-11-14T06:00:00Z"
+          },
+          "path": {
+            "S": "api/test"
+          }
+        }
+      }
+    },
+    {
+      "PutRequest":{
+        "Item": {
+          "api_key": {
+            "S": "key2"
+          },
+          "timestamp": {
+            "S": "2020-12-14T08:00:00Z"
+          },
+          "path": {
+            "S": "api/test"
+          }
+        }
+      }
+    },
+    {
+      "PutRequest":{
+        "Item": {
+          "api_key": {
+            "S": "key1"
+          },
+          "timestamp": {
+            "S": "2020-12-14T09:00:00Z"
+          },
+          "path": {
+            "S": "api/dummy"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/gateway/model/model.go
+++ b/gateway/model/model.go
@@ -19,8 +19,11 @@ type Field struct {
 	Template      URITemplate
 	Path          URITemplate
 	ForwardSchema string
-	Num           int
-	Max           interface{}
+	// Num represents the recent number of api calls.
+	Num int
+	// Max represents the maximum api call limit if Max's type is int.
+	// If it is "-", the number of the api calls has no limit.
+	Max interface{}
 }
 
 type Fields []Field


### PR DESCRIPTION
APIアクセスログのdynamoDBから（apikey, path）のセットごとの使用回数を集計する。

apiリクエスト時に使用回数が制限を超えていないか確認するが、使用回数の問い合わせ結果は一定時間キャッシュする。