### PR TITLE
外部APIアクセスの例を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,31 @@ docker compose build \
 # Launch apidoor services
 docker compose up -d
 
-# Set your first API routing through management-api
+# Set your first API routing through management-api, and check apidoor works
+# Case 1: original api
 curl -X POST -H "Content-Type: application/json" \
 -d '{"api_key": "key", "path": "test", "forward_url": "http://test-server:3333/welcome"}' localhost:3001/mgmt/api
 
-# Check apidoor works
-curl -H "Content-Type: application/json" -H "Authorization:key" localhost:3000/test
+curl -H "Content-Type: application/json" -H "X-Apidoor-Authorization:key" localhost:3000/test
 # welcome to apidoor!
+
+# Case 2: external api using https scheme with query parameter
+curl -X POST -H "Content-Type: application/json" \
+-d '{"api_key": "key", "path": "github/search", "forward_url": "https://api.github.com/search/repositories"}'\
+localhost:3001/mgmt/api
+
+curl -H "Content-Type: application/json" -H "X-Apidoor-Authorization:key" localhost:3000/github/search?q=apidoor
+# <search result>
+
+# Case 3: external api with access token
+# You must generate your GitHub's access token allowing to access repo:status in advance
+curl -X POST -H "Content-Type: application/json" \
+-d '{"api_key": "key", "path": "github/user/repos", "forward_url": "https://api.github.com/user/repos"}' \
+localhost:3001/mgmt/api
+
+curl -H "Content-Type: application/json" -H "X-Apidoor-Authorization:key" \
+-H "Authorization: token <your GitHub's access token>" localhost:3000/github/user/repos
+# <your repositories' status>
 
 # Check log file is provided
 cat ./log/log.csv

--- a/README_ja.md
+++ b/README_ja.md
@@ -39,13 +39,31 @@ docker compose build \
 # Launch apidoor services
 docker compose up -d
 
-# Set your first API routing through management-api
+# Set your first API routing through management-api, and check apidoor works
+# Case 1: original api
 curl -X POST -H "Content-Type: application/json" \
 -d '{"api_key": "key", "path": "test", "forward_url": "http://test-server:3333/welcome"}' localhost:3001/mgmt/api
 
-# Check apidoor works
-curl -H "Content-Type: application/json" -H "Authorization:key" localhost:3000/test
+curl -H "Content-Type: application/json" -H "X-Apidoor-Authorization:key" localhost:3000/test
 # welcome to apidoor!
+
+# Case 2: external api using https scheme with query parameter
+curl -X POST -H "Content-Type: application/json" \
+-d '{"api_key": "key", "path": "github/search", "forward_url": "https://api.github.com/search/repositories"}'\
+localhost:3001/mgmt/api
+
+curl -H "Content-Type: application/json" -H "X-Apidoor-Authorization:key" localhost:3000/github/search?q=apidoor
+# <search result>
+
+# Case 3: external api with access token
+# You must generate your GitHub's access token allowing to access repo:status in advance
+curl -X POST -H "Content-Type: application/json" \
+-d '{"api_key": "key", "path": "github/user/repos", "forward_url": "https://api.github.com/user/repos"}' \
+localhost:3001/mgmt/api
+
+curl -H "Content-Type: application/json" -H "X-Apidoor-Authorization:key" \
+-H "Authorization: token <your GitHub's access token>" localhost:3000/github/user/repos
+# <your repositories' status>
 
 # Check log file is provided
 cat ./log/log.csv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
             - AWS_ACCESS_KEY_ID=dummy
             - AWS_SECRET_ACCESS_KEY=dummy
             - AWS_DEFAULT_REGION=ap-northeast-1
-            - AWS_DEFAULT_OUTPUT=json
             - LOG_PATH=/log/log.csv
             - NO_PROXY=test-server
         volumes:
@@ -59,7 +58,6 @@ services:
             - AWS_ACCESS_KEY_ID=dummy
             - AWS_SECRET_ACCESS_KEY=dummy
             - AWS_DEFAULT_REGION=ap-northeast-1
-            - AWS_DEFAULT_OUTPUT=json
     test-server:
         build: ./quickstart
         container_name: test-server

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -23,7 +23,7 @@ func (h DefaultHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apikey := r.Header.Get("Authorization")
+	apikey := r.Header.Get("X-Apidoor-Authorization")
 	if apikey == "" {
 		log.Print("No authorization key")
 		http.Error(w, "no authorization request header", http.StatusBadRequest)
@@ -97,7 +97,7 @@ func (h DefaultHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 func setRequestHeader(src, dist *http.Request) {
 	dist.Header = src.Header
-	dist.Header.Del("Authorization")
+	dist.Header.Del("X-Apidoor-Authorization")
 	dist.Header.Del("Connection")
 	dist.Header.Del("Cookie")
 }

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -157,7 +157,7 @@ func TestHandle(t *testing.T) {
 			r := httptest.NewRequest(method, tt.request, nil)
 			r.Header.Set("Content-Type", tt.content)
 			if tt.apikey != "" {
-				r.Header.Set("Authorization", tt.apikey)
+				r.Header.Set("X-Apidoor-Authorization", tt.apikey)
 			}
 			w := httptest.NewRecorder()
 			h.Handle(w, r)


### PR DESCRIPTION
やったこと
* gatewayのauthorizationヘッダの名前を変更
* 外部APIアクセスの例をREADMEに追加