### PR TITLE
gatewayのforward pathの生成のバグ修正，ログの変更

### DIFF
--- a/management-api/post_api_routing.go
+++ b/management-api/post_api_routing.go
@@ -59,6 +59,7 @@ func PostAPIRouting(w http.ResponseWriter, r *http.Request) {
 	if err := apirouting.ApiDBDriver.PostRouting(r.Context(), req.ApiKey, req.Path, req.ForwardURL); err != nil {
 		log.Printf("post api routing db error: %v", err)
 		http.Error(w, "server error", http.StatusInternalServerError)
+		return
 	}
 
 	w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
* /user/{userID} のようなパスパラメータがある時，フォワード先のURLの生成が出来ていなかったため修正した
* 呼び出し先のAPIでエラーが起きた時，クライエントへのレスポンスに元々のボディが含まれていなかったので修正した