### PR TITLE
gatewayのAPIトークン自動付加機能の追加

### DIFF
--- a/dynamo_table/access_token_table.json
+++ b/dynamo_table/access_token_table.json
@@ -1,0 +1,19 @@
+{
+  "TableName": "access_token",
+  "KeySchema": [
+    {
+      "AttributeName": "key",
+      "KeyType": "HASH"
+    },
+  ],
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "key",
+      "AttributeType": "S"
+    },
+  ],
+  "ProvisionedThroughput": {
+    "ReadCapacityUnits": 1,
+    "WriteCapacityUnits": 1
+  }
+}

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4 as build
+FROM golang:1.17.7 as build
 WORKDIR /gateway
 COPY go.mod go.sum ./
 RUN ["go", "mod", "download"]

--- a/gateway/datasource/datasource.go
+++ b/gateway/datasource/datasource.go
@@ -7,4 +7,5 @@ import (
 
 type DataSource interface {
 	GetFields(ctx context.Context, key string) (model.Fields, error)
+	GetAccessTokens(ctx context.Context, apikey, templatePath string) (*model.AccessTokens, error)
 }

--- a/gateway/datasource/redis/redis.go
+++ b/gateway/datasource/redis/redis.go
@@ -56,3 +56,8 @@ func (rd DataSource) GetFields(ctx context.Context, key string) (model.Fields, e
 
 	return fields, nil
 }
+
+func (dd DataSource) GetAccessTokens(ctx context.Context, apikey, templatePath string) (*model.AccessTokens, error) {
+	//TODO: impl
+	return nil, &model.MyError{Message: "for redis get access tokens is not implemented"}
+}

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -374,7 +374,7 @@ func TestSetStoredTokens(t *testing.T) {
 			}
 			req.Header.Add("X-Apidoor-Authorization", apikey)
 
-			err = setStoredTokens(context.Background(), tt.templatePath, req, h.DataSource)
+			err = h.addStoredTokens(context.Background(), req, tt.templatePath)
 			if err != nil {
 				if errors.Is(err, tt.wantErr) {
 					t.Errorf("returned error differs: want %v, got %v", tt.wantErr, err)

--- a/gateway/model/accesstokens.go
+++ b/gateway/model/accesstokens.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type ParamType string
+
+const (
+	Header          ParamType = "header"
+	Query                     = "query"
+	BodyFormEncoded           = "body_form_encoded"
+)
+
+type AccessToken struct {
+	ParamType ParamType `dynamo:"param_type"`
+	Key       string    `dynamo:"key"`
+	Value     string    `dynamo:"value"`
+}
+
+type NotSupportedParamType string
+
+func (nsp NotSupportedParamType) Error() string { return string(nsp) }
+
+func (at AccessToken) addTokenToRequest(r *http.Request) error {
+	switch at.ParamType {
+	case Header:
+		if r.Header.Get(at.Key) == "" {
+			r.Header.Add(at.Key, at.Value)
+		}
+	case Query:
+		if !r.URL.Query().Has(at.Key) {
+			query := r.URL.Query()
+			query.Add(at.Key, at.Value)
+			r.URL.RawQuery = query.Encode()
+		}
+	case BodyFormEncoded:
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/x-www-form-urlencoded" {
+			return fmt.Errorf("content-Type header is not application/x-www-form-urlencoded, got %s", contentType)
+		}
+		if err := r.ParseForm(); err != nil {
+			return fmt.Errorf("reading body as form data failed: %w", err)
+		}
+		if !r.PostForm.Has(at.Key) {
+			r.PostForm.Add(at.Key, at.Value)
+			r.Body = io.NopCloser(strings.NewReader(r.PostForm.Encode()))
+		}
+	default:
+		return fmt.Errorf("unsupported param type: %v", at.ParamType)
+	}
+	return nil
+}
+
+type AccessTokens struct {
+	Tokens []AccessToken `dynamo:"tokens"`
+}
+
+func (ats AccessTokens) AddTokensToRequest(r *http.Request) error {
+	var errors error
+	for _, v := range ats.Tokens {
+		if err := v.addTokenToRequest(r); err != nil {
+			if errors == nil {
+				errors = err
+			} else {
+				errors = fmt.Errorf("; %w", err)
+			}
+		}
+	}
+	return errors
+}

--- a/gateway/model/model.go
+++ b/gateway/model/model.go
@@ -48,8 +48,9 @@ func (f Field) createForwardURL(query map[string]string) string {
 type Fields []Field
 
 type FieldResult struct {
-	Field      Field
-	ForwardURL string
+	Field        Field
+	ForwardURL   string
+	TemplatePath string
 }
 
 func (f Fields) LookupTemplate(path string) (*FieldResult, error) {
@@ -57,7 +58,7 @@ func (f Fields) LookupTemplate(path string) (*FieldResult, error) {
 	for _, v := range f {
 		if params, ok := u.Match(v.Template); ok {
 			forwardURL := v.createForwardURL(params)
-			return &FieldResult{Field: v, ForwardURL: forwardURL}, nil
+			return &FieldResult{Field: v, ForwardURL: forwardURL, TemplatePath: v.Template.JoinPath()}, nil
 		}
 	}
 	return nil, ErrUnauthorizedRequest // Not found path


### PR DESCRIPTION
API トークンなどがデータベースに登録されているとき、gatewayが自動でパラメータに付加する。
既にパラメータが存在している場合は何もしない。