### PR TITLE
API利用回数集計を契約ベースに変更

### DIFF
--- a/dynamo_table/access_log_table.json
+++ b/dynamo_table/access_log_table.json
@@ -2,7 +2,7 @@
   "TableName": "access_log",
   "KeySchema": [
     {
-      "AttributeName": "api_key",
+      "AttributeName": "contract_id",
       "KeyType": "HASH"
     },
     {
@@ -12,8 +12,8 @@
   ],
   "AttributeDefinitions": [
     {
-      "AttributeName": "api_key",
-      "AttributeType": "S"
+      "AttributeName": "contract_id",
+      "AttributeType": "N"
     },
     {
       "AttributeName": "timestamp",

--- a/gateway/datasource/dynamo/dynamo.go
+++ b/gateway/datasource/dynamo/dynamo.go
@@ -12,12 +12,6 @@ import (
 	"os"
 )
 
-type APIRouting struct {
-	APIKey     string `dynamo:"api_key"`
-	Path       string `dynamo:"path"`
-	ForwardURL string `dynamo:"forward_url"`
-}
-
 type DataSource struct {
 	client          *dynamo.DB
 	apiRoutingTable string
@@ -50,7 +44,7 @@ func New() *DataSource {
 }
 
 func (dd DataSource) GetFields(ctx context.Context, key string) (model.Fields, error) {
-	var routingList []*APIRouting
+	var routingList []*datasource.Routing
 	err := dd.client.Table(dd.apiRoutingTable).
 		Get("api_key", key).
 		AllWithContext(ctx, &routingList)
@@ -63,7 +57,7 @@ func (dd DataSource) GetFields(ctx context.Context, key string) (model.Fields, e
 
 	fields := make([]model.Field, 0, len(routingList))
 	for _, routing := range routingList {
-		field, err := datasource.CreateField(ctx, routing.APIKey, routing.Path, routing.ForwardURL)
+		field, err := datasource.CreateField(ctx, routing)
 		if err != nil {
 			return nil, fmt.Errorf("fetch field, key = %v, hk = %v, forwardURL = %v, error: %w",
 				routing.APIKey, routing.Path, routing.ForwardURL, err)

--- a/gateway/datasource/field.go
+++ b/gateway/datasource/field.go
@@ -12,28 +12,29 @@ var (
 	defaultAPICallMaxLimit = 100
 )
 
-func CreateField(ctx context.Context, key, hkey, forwardURL string) (model.Field, error) {
+func CreateField(ctx context.Context, routing *Routing) (model.Field, error) {
 	var schema string
-	if strings.HasPrefix(forwardURL, "http://") {
+	if strings.HasPrefix(routing.ForwardURL, "http://") {
 		schema = "http"
-		forwardURL = strings.Replace(forwardURL, "http://", "", 1)
-		fmt.Println("Redis After:", forwardURL)
-	} else if strings.HasPrefix(forwardURL, "https://") {
+		routing.ForwardURL = strings.Replace(routing.ForwardURL, "http://", "", 1)
+		fmt.Println("Redis After:", routing.ForwardURL)
+	} else if strings.HasPrefix(routing.ForwardURL, "https://") {
 		schema = "https"
-		forwardURL = strings.Replace(forwardURL, "https://", "", 1)
+		routing.ForwardURL = strings.Replace(routing.ForwardURL, "https://", "", 1)
 	} else {
 		// スキーマが存在しない(tcpなどのスキーマは非対応)
 		schema = "http"
 	}
-	path := model.NewURITemplate(forwardURL)
-	template := model.NewURITemplate(hkey)
+	path := model.NewURITemplate(routing.ForwardURL)
+	template := model.NewURITemplate(routing.Path)
 
-	count, err := logger.APICounter.GetCount(ctx, key, template)
+	count, err := logger.APICounter.GetCount(ctx, routing.ContractID, template)
 	if err != nil {
 		return model.Field{}, fmt.Errorf("fetch api count error: %w", err)
 	}
 
 	return model.Field{
+		ContractID:    routing.ContractID,
 		Template:      template,
 		ForwardSchema: schema,
 		Path:          path,

--- a/gateway/datasource/model.go
+++ b/gateway/datasource/model.go
@@ -1,0 +1,8 @@
+package datasource
+
+type Routing struct {
+	APIKey     string `dynamo:"api_key"`
+	Path       string `dynamo:"path"`
+	ForwardURL string `dynamo:"forward_url"`
+	ContractID int    `dynamo:"contract_id"`
+}

--- a/gateway/datasource/redis/redis.go
+++ b/gateway/datasource/redis/redis.go
@@ -41,7 +41,12 @@ func (rd DataSource) GetFields(ctx context.Context, key string) (model.Fields, e
 
 		pathValue := rd.client.HGet(ctx, key, hk).Val()
 
-		field, err := datasource.CreateField(ctx, key, hk, pathValue)
+		field, err := datasource.CreateField(ctx, &datasource.Routing{
+			APIKey:     key,
+			Path:       hk,
+			ForwardURL: pathValue,
+			ContractID: 0, // TODO: redisでのデータ管理
+		})
 		if err != nil {
 			return nil, fmt.Errorf("fetch field, key = %v, hk = %v, forwardURL = %v, error: %w",
 				key, hk, pathValue, err)

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -98,7 +98,7 @@ func (h DefaultHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.Appender.Do(apikey, result.Field.Path.JoinPath(), r, res, calcBillingStatus); err != nil {
+	if err := h.Appender.Do(result.ContractID, apikey, result.Field.Path.JoinPath(), r, res, calcBillingStatus); err != nil {
 		log.Printf("[ERROR] appender write err: %v\n", err)
 	}
 }

--- a/gateway/logger/counter.go
+++ b/gateway/logger/counter.go
@@ -20,10 +20,10 @@ type APICallCounter struct {
 	sync.Map
 }
 
-func (ac *APICallCounter) GetCount(ctx context.Context, apikey string, path model.URITemplate) (int, error) {
+func (ac *APICallCounter) GetCount(ctx context.Context, contractID int, path model.URITemplate) (int, error) {
 	key := counterKey{
-		apikey: apikey,
-		path:   path.JoinPath(),
+		contractID: contractID,
+		path:       path.JoinPath(),
 	}
 	return ac.getCount(ctx, key)
 }
@@ -40,7 +40,7 @@ func (ac *APICallCounter) getCount(ctx context.Context, key counterKey) (int, er
 }
 
 func (ac *APICallCounter) updateCount(ctx context.Context, key counterKey) (int, error) {
-	count64, err := db.countBillingAccessLogDB(ctx, key.apikey, key.path, ac.countStartAt())
+	count64, err := db.countBillingAccessLogDB(ctx, key.contractID, key.path, ac.countStartAt())
 	if err != nil {
 		return 0, fmt.Errorf("count api call db error: %w", err)
 	}
@@ -62,8 +62,8 @@ func (ac *APICallCounter) countExpireAt() time.Time {
 }
 
 type counterKey struct {
-	apikey string
-	path   string
+	contractID int
+	path       string
 }
 
 type counterStat struct {

--- a/gateway/logger/dynamo.go
+++ b/gateway/logger/dynamo.go
@@ -48,9 +48,9 @@ func (ad accessLogDB) postAccessLogDB(ctx context.Context, item LogItem) error {
 		Put(item).RunWithContext(ctx)
 }
 
-func (ad accessLogDB) countBillingAccessLogDB(ctx context.Context, apikey, path string, startAt time.Time) (int64, error) {
+func (ad accessLogDB) countBillingAccessLogDB(ctx context.Context, contractID int, path string, startAt time.Time) (int64, error) {
 	return ad.client.Table(ad.accessLogTable).
-		Get("api_key", apikey).
+		Get("contract_id", contractID).
 		Range("timestamp", dynamo.GreaterOrEqual, startAt).
 		Filter("'path' = ?", path).
 		Filter("'billing_status' = ?", Billing).

--- a/gateway/logger/testdata/get_counter_items.json
+++ b/gateway/logger/testdata/get_counter_items.json
@@ -3,8 +3,8 @@
     {
       "PutRequest":{
         "Item": {
-          "api_key": {
-            "S": "key1"
+          "contract_id": {
+            "N": "0"
           },
           "timestamp": {
             "S": "2020-12-14T06:00:00Z"
@@ -24,8 +24,8 @@
     {
       "PutRequest":{
         "Item": {
-          "api_key": {
-            "S": "key1"
+          "contract_id": {
+            "N": "0"
           },
           "timestamp": {
             "S": "2020-12-13T06:00:00Z"
@@ -45,8 +45,8 @@
     {
       "PutRequest":{
         "Item": {
-          "api_key": {
-            "S": "key1"
+          "contract_id": {
+            "N": "0"
           },
           "timestamp": {
             "S": "2020-11-14T06:00:00Z"
@@ -66,8 +66,8 @@
     {
       "PutRequest":{
         "Item": {
-          "api_key": {
-            "S": "key2"
+          "contract_id": {
+            "N": "1"
           },
           "timestamp": {
             "S": "2020-12-14T08:00:00Z"
@@ -87,8 +87,8 @@
     {
       "PutRequest":{
         "Item": {
-          "api_key": {
-            "S": "key1"
+          "contract_id": {
+            "N": "0"
           },
           "timestamp": {
             "S": "2020-12-14T09:00:00Z"
@@ -108,8 +108,8 @@
     {
       "PutRequest":{
         "Item": {
-          "api_key": {
-            "S": "key1"
+          "contract_id": {
+            "N": "0"
           },
           "timestamp": {
             "S": "2020-12-14T06:01:00Z"

--- a/gateway/model/model.go
+++ b/gateway/model/model.go
@@ -17,6 +17,7 @@ func (err *MyError) Error() string {
 }
 
 type Field struct {
+	ContractID int
 	// Template is a gateway path
 	Template URITemplate
 	// Path is a  destination api path
@@ -51,6 +52,7 @@ type FieldResult struct {
 	Field        Field
 	ForwardURL   string
 	TemplatePath string
+	ContractID   int
 }
 
 func (f Fields) LookupTemplate(path string) (*FieldResult, error) {
@@ -58,7 +60,7 @@ func (f Fields) LookupTemplate(path string) (*FieldResult, error) {
 	for _, v := range f {
 		if params, ok := u.Match(v.Template); ok {
 			forwardURL := v.createForwardURL(params)
-			return &FieldResult{Field: v, ForwardURL: forwardURL, TemplatePath: v.Template.JoinPath()}, nil
+			return &FieldResult{Field: v, ForwardURL: forwardURL, TemplatePath: v.Template.JoinPath(), ContractID: v.ContractID}, nil
 		}
 	}
 	return nil, ErrUnauthorizedRequest // Not found path


### PR DESCRIPTION
close #86 

API利用回数集計がこれまで(apikey, path)ごとに集計していたが、(contract, path)ごとに集計するように変更した